### PR TITLE
Add pv-migrate support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine
 
 # Ignore to update versions here
-# docker build --no-cache --build-arg KUBECTL_VERSION=${kubectl} --build-arg HELM_VERSION=${helm} --build-arg DOCTL_VERION=${doctl} -t ${image}:${tag} .
+# docker build --no-cache --build-arg KUBECTL_VERSION=${kubectl} --build-arg HELM_VERSION=${helm} --build-arg DOCTL_VERION=${doctl} --build-arg PV_MIGRATE_VERSION=${pvmigrate} -t ${image}:${tag} .
 ARG HELM_VERSION=3.2.1
 ARG KUBECTL_VERSION=1.21.3
 ARG DOCTL_VERSION=1.62.0
+ARG PVMIGRATE_VERSION=2.2.1
 
 # Install helm (latest release)
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
@@ -26,5 +27,10 @@ RUN apk add --update --no-cache tar && \
   curl -sL https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz |tar xvz -C /usr/bin && \
   chmod +x /usr/bin/doctl && \
   apk del tar
+
+# Install pv-migrate (latest release)
+RUN wget https://github.com/utkuozdemir/pv-migrate/releases/download/${PVMIGRATE_VERSION}/pv-migrate_${PVMIGRATE_VERSION}_linux_x86_64.tar.gz && \
+  tar -xvzf pv-migrate_${DF_K8S_PV_MIGRATE_VERSION}_linux_x86_64.tar.gz && \
+  mv pv-migrate /usr/local/bin
 
 WORKDIR /apps

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN apk add --update --no-cache tar && \
   apk del tar
 
 # Install pv-migrate (latest release)
-RUN wget https://github.com/utkuozdemir/pv-migrate/releases/download/${PVMIGRATE_VERSION}/pv-migrate_${PVMIGRATE_VERSION}_linux_x86_64.tar.gz && \
-  tar -xvzf pv-migrate_${DF_K8S_PV_MIGRATE_VERSION}_linux_x86_64.tar.gz && \
+RUN wget https://github.com/utkuozdemir/pv-migrate/releases/download/v${PVMIGRATE_VERSION}/pv-migrate_v${PVMIGRATE_VERSION}_linux_x86_64.tar.gz && \
+  tar -xvzf pv-migrate_v${PVMIGRATE_VERSION}_linux_x86_64.tar.gz && \
   mv pv-migrate /usr/local/bin
 
 WORKDIR /apps

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ DigitalOcean tool images with necessary tools, it can be used as normal kubectl 
 - [doctl](https://github.com/digitalocean/doctl) (latest release, when run the build)
 - [kubectl](https://github.com/kubernetes/kubectl) (latest release, when run the build)
 - [helm](https://github.com/helm/helm) (latest release, when run the build)
+- [pv-migrate](https://github.com/utkuozdemir/pv-migrate) (latest release, when run the build)
 - General tools, such as bash, curl
 - Recommend any other tools by raise PR.
 

--- a/build.sh
+++ b/build.sh
@@ -48,18 +48,26 @@ function get_latest_doctl_version() {
   echo $doctl
 }
 
+function get_latest_pvmigrate_version() {
+  local doctl=$(curl -s https://github.com/utkuozdemir/pv-migrate/releases)
+  pvmigrate=$(echo $pvmigrate\" |grep -oP '(?<=tag\/v)[0-9][^"<]*'|grep -v \-|sort -Vr|head -1)
+  echo $pvmigrate
+}
+
 build() {
 
   echo docker build --no-cache \
     --build-arg KUBECTL_VERSION=${tag} \
     --build-arg HELM_VERSION=${latest_helm_version} \
     --build-arg DOCTL_VERSION=${latest_doctl_version} \
+    --build-arg PVMIGRATE_VERSION=${latest_pvmigrate_version} \
     -t ${image}:${tag} .
 
   docker build --no-cache \
     --build-arg KUBECTL_VERSION=${tag} \
     --build-arg HELM_VERSION=${latest_helm_version} \
     --build-arg DOCTL_VERSION=${latest_doctl_version} \
+    --build-arg PVMIGRATE_VERSION=${latest_pvmigrate_version} \
     -t ${image}:${tag} .
 
   # run test
@@ -97,6 +105,9 @@ main() {
 
   latest_doctl_version=$(get_latest_doctl_version)
   echo "latest doctl version is ${latest_doctl_version}"
+
+  latest_pvmigrate_version}=$(get_latest_pvmigrate_version)
+  echo "latest pv-migrate version is ${latest_pvmigrate_version}"
   
   for tag in "${latest_kubectl_versions[@]}"; do
     echo ${tag}

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ function get_latest_doctl_version() {
 }
 
 function get_latest_pvmigrate_version() {
-  local doctl=$(curl -s https://github.com/utkuozdemir/pv-migrate/releases)
+  local pvmigrate=$(curl -s https://github.com/utkuozdemir/pv-migrate/releases)
   pvmigrate=$(echo $pvmigrate\" |grep -oP '(?<=tag\/v)[0-9][^"<]*'|grep -v \-|sort -Vr|head -1)
   echo $pvmigrate
 }
@@ -86,7 +86,7 @@ build() {
   if [[ "$CIRCLE_BRANCH" == "main" ]]; then
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     docker push ${image}:${tag}
-    
+
     # update latest image
     docker pull ${image}:${latest_kubectl_versions[0]}
     docker tag ${image}:${latest_kubectl_versions[0]} ${image}:latest
@@ -106,9 +106,9 @@ main() {
   latest_doctl_version=$(get_latest_doctl_version)
   echo "latest doctl version is ${latest_doctl_version}"
 
-  latest_pvmigrate_version}=$(get_latest_pvmigrate_version)
+  latest_pvmigrate_version=$(get_latest_pvmigrate_version)
   echo "latest pv-migrate version is ${latest_pvmigrate_version}"
-  
+
   for tag in "${latest_kubectl_versions[@]}"; do
     echo ${tag}
     status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag})


### PR DESCRIPTION
We've found this tool to be pretty great for moving and syncing data between pvcs and clusters. And some storage classes (e.g. OpenEBS) which is in the digitalocean marketplace don't support PVC resizing so migrating data to new storage PVCs is pretty handy.

Thought it might be a good addition to the base toolset in this container.